### PR TITLE
Fixes #11 Handle team-color loading errors

### DIFF
--- a/code.js
+++ b/code.js
@@ -88,9 +88,14 @@ class TeamColorsManager {
             }
             const teamStyles = [];
             for (let key of teamColorKeys) {
-                const style = yield figma.importStyleByKeyAsync(key);
-                if (style) {
-                    teamStyles.push(style);
+                try {
+                    const style = yield figma.importStyleByKeyAsync(key);
+                    if (style) {
+                        teamStyles.push(style);
+                    }
+                }
+                catch (e) {
+                    console.log(e);
                 }
             }
             return teamStyles;

--- a/code.ts
+++ b/code.ts
@@ -86,9 +86,13 @@ class TeamColorsManager {
 
     const teamStyles = []
     for (let key of teamColorKeys) {
-      const style = await figma.importStyleByKeyAsync(key)
-      if (style) {
-        teamStyles.push(style)
+      try {
+        const style = await figma.importStyleByKeyAsync(key)
+        if (style) {
+          teamStyles.push(style)
+        }
+      } catch (e) {
+        console.log(e)
       }
     }
     return teamStyles


### PR DESCRIPTION
I found out it crashes when you choose "Save colorStyles from Team Library" with invalid team-colors (includes local styles), and then any modes.. 😫 