### PR TITLE
Simplify replacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,12 @@
 # Dark Mode Switcher
 Provides that can toggle light/dark color.
 
-You can specify your favor ColorStyle which separated by “/” and contains “Dark"("dark"), “Light”("light") or “Elevated”("elevated") key.
+You can specify your favor ColorStyle which contains “Dark"("dark"), “Light”("light") or “Elevated”("elevated") key.
 Exmaple:
 
 - `Background/Dark/Primary` :point_right: `Background/Light/Primary`
 - `Background/Light/Primary` :point_right: `Background/Elevated/Primary`
+- `Background Primary (Light)` :point_right: `Background Primary (Dark)`
 
 
 ## NOTE: For Team Library Supports

--- a/code.js
+++ b/code.js
@@ -46,12 +46,12 @@ function replaceNodes(nodes) {
         const fillStyleName = styleManager.getStyleNameById(node.fillStyleId);
         const strokeStyleName = styleManager.getStyleNameById(node.strokeStyleId);
         if (fillStyleName != null) {
-            const replacedColorStyleName = replaceColorStyleName(fillStyleName);
+            const replacedColorStyleName = Replacer.replace(fillStyleName, mode);
             const replacedFillStyleId = styleManager.getStyleIdByName(replacedColorStyleName);
             node.fillStyleId = replacedFillStyleId;
         }
         if (strokeStyleName != null) {
-            const replacedStrokeColorStyleName = replaceColorStyleName(strokeStyleName);
+            const replacedStrokeColorStyleName = Replacer.replace(strokeStyleName, mode);
             const replacedStrokeStyleId = styleManager.getStyleIdByName(replacedStrokeColorStyleName);
             node.strokeStyleId = replacedStrokeStyleId;
         }
@@ -59,15 +59,6 @@ function replaceNodes(nodes) {
             replaceNodes(node.children);
         }
     }
-}
-function replaceColorStyleName(paintStyleName) {
-    const splitPaintStyleName = paintStyleName.split('/');
-    const replacedNodePaintStyleNames = [];
-    for (let i = 0; i < splitPaintStyleName.length; i++) {
-        const name = new StyleKeyword(splitPaintStyleName[i], mode);
-        replacedNodePaintStyleNames.push(name.switch());
-    }
-    return replacedNodePaintStyleNames.join('/');
 }
 class TeamColorsManager {
     static saveTeamStyleKeysToStorage() {
@@ -116,29 +107,22 @@ class StyleManager {
         return (style != undefined) ? style.id : null;
     }
 }
-class StyleKeyword {
-    constructor(name, mode) {
-        this.name = name;
-        this.mode = mode;
-    }
-    switch() {
-        if (!this.isModeKeyword) {
-            return this.name;
+class Replacer {
+    static replace(name, to) {
+        const keywords = Object.keys(Mode).map((key) => Mode[key]);
+        for (let from of keywords) {
+            if (name.match(from)) {
+                return name.replace(from, to);
+            }
+            const capitalizedFrom = this.capitalize(from);
+            if (name.match(capitalizedFrom)) {
+                return name.replace(capitalizedFrom, this.capitalize(to));
+            }
         }
-        if (this.capitalized(this.name)) {
-            return this.capitalize(this.mode);
-        }
-        return this.mode;
+        return name;
     }
-    get isModeKeyword() {
-        const found = Object.keys(Mode).find((mode) => mode.toLowerCase() === this.name.toLowerCase());
-        return (found != undefined);
-    }
-    capitalize(text) {
+    static capitalize(text) {
         return text.charAt(0).toUpperCase() + text.toLowerCase().slice(1);
-    }
-    capitalized(text) {
-        return (text === this.capitalize(text));
     }
 }
 main();

--- a/code.ts
+++ b/code.ts
@@ -38,13 +38,13 @@ function replaceNodes(nodes: Array<any>): void {
     const fillStyleName: string = styleManager.getStyleNameById(node.fillStyleId)
     const strokeStyleName: string = styleManager.getStyleNameById(node.strokeStyleId)
     if (fillStyleName != null) {
-      const replacedColorStyleName: string = replaceColorStyleName(fillStyleName)
+      const replacedColorStyleName: string = Replacer.replace(fillStyleName, mode)
       const replacedFillStyleId: string = styleManager.getStyleIdByName(replacedColorStyleName)
       node.fillStyleId = replacedFillStyleId
     }
 
     if (strokeStyleName != null) {
-      const replacedStrokeColorStyleName: string = replaceColorStyleName(strokeStyleName)
+      const replacedStrokeColorStyleName: string = Replacer.replace(strokeStyleName, mode)
       const replacedStrokeStyleId: string = styleManager.getStyleIdByName(replacedStrokeColorStyleName)
       node.strokeStyleId = replacedStrokeStyleId
     }
@@ -54,18 +54,6 @@ function replaceNodes(nodes: Array<any>): void {
     }
   }
 }
-
-function replaceColorStyleName(paintStyleName: string): string {
-  const splitPaintStyleName = paintStyleName.split('/')
-  const replacedNodePaintStyleNames = []
-
-  for (let i = 0; i < splitPaintStyleName.length; i++) {
-    const name = new StyleKeyword(splitPaintStyleName[i], mode)
-    replacedNodePaintStyleNames.push(name.switch())
-  }
-  return replacedNodePaintStyleNames.join('/')
-}
-
 class TeamColorsManager {
   static key: string = "darkModeSwitcher.teamColorKeys"
 
@@ -117,36 +105,23 @@ class StyleManager {
   }
 }
 
-class StyleKeyword {
-  name: string
-  mode: string
-
-  constructor(name: string, mode: string) {
-    this.name = name
-    this.mode = mode
-  }
-
-  switch(): string {
-    if (!this.isModeKeyword) {
-      return this.name
+class Replacer {
+  static replace(name: string, to: string): string {
+    const keywords = Object.keys(Mode).map((key) => Mode[key])
+    for (let from of keywords) {
+      if (name.match(from)) {
+        return name.replace(from, to)
+      }
+      const capitalizedFrom = this.capitalize(from)
+      if (name.match(capitalizedFrom)) {
+        return name.replace(capitalizedFrom, this.capitalize(to))
+      }
     }
-    if (this.capitalized(this.name)) {
-      return this.capitalize(this.mode)
-    }
-    return this.mode
+    return name
   }
 
-  get isModeKeyword(): boolean {
-    const found = Object.keys(Mode).find((mode) => mode.toLowerCase() === this.name.toLowerCase())
-    return (found != undefined)
-  }
-
-  capitalize(text: string): string {
+  static capitalize(text: string): string {
     return text.charAt(0).toUpperCase() + text.toLowerCase().slice(1)
-  }
-
-  capitalized(text: string): boolean {
-    return (text === this.capitalize(text))
   }
 }
 


### PR DESCRIPTION
We decided to split by `/` and replace words at first phase, but it causes lack of flexibility. I simplified the flow for more flexibly to use using `Replacer` class instead of `StyleKeyword`. Then finally it started to support not `/` separated names, ex: `Background Primary (Light)`.